### PR TITLE
add missing linker dependencies

### DIFF
--- a/loaders/CMakeLists.txt
+++ b/loaders/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_executable(vcf_into_sqlite vcf_into_sqlite.cc common.hpp strlcpy.h)
-target_link_libraries(vcf_into_sqlite PRIVATE genomicsqlite SQLiteCpp hts)
+target_link_libraries(vcf_into_sqlite PRIVATE pthread libsqlite3.so.0 genomicsqlite SQLiteCpp hts)
 
 add_executable(vcf_lines_into_sqlite vcf_lines_into_sqlite.cc common.hpp strlcpy.h)
-target_link_libraries(vcf_lines_into_sqlite PRIVATE genomicsqlite SQLiteCpp)
+target_link_libraries(vcf_lines_into_sqlite PRIVATE pthread libsqlite3.so.0 genomicsqlite SQLiteCpp)
 
 add_executable(sam_into_sqlite sam_into_sqlite.cc common.hpp strlcpy.h)
-target_link_libraries(sam_into_sqlite PRIVATE genomicsqlite SQLiteCpp hts)
+target_link_libraries(sam_into_sqlite PRIVATE pthread libsqlite3.so.0 genomicsqlite SQLiteCpp hts)


### PR DESCRIPTION
This patch fixes missing symbols when linking with a modern toolchain. Newer linkers require specifying all dependencies and do not resolve symbols that are present in dependent libraries that are not explicitly named. Example error without patch:

```
...
[ 81%] Linking CXX executable vcf_lines_into_sqlite
/nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: CMakeFiles/vcf_lines_into_sqlite.dir/vcf_lines_into_sqlite.cc.o: undefined reference to symbol 'sqlite3_config'
/nix/store/p792j5f44l3f0xi7ai5jllwnxqwnka88-binutils-2.31.1/bin/ld: /nix/store/l3m86gxh34cm0m1xlsvpmcmxfszsagsw-sqlite-3.33.0/lib/libsqlite3.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```