### PR TITLE
Use single quote to quote SQL string literal

### DIFF
--- a/bindings/python/genomicsqlite/__init__.py
+++ b/bindings/python/genomicsqlite/__init__.py
@@ -291,7 +291,7 @@ def _cli(argv=None):
         # interactive mode:
         cmd += [
             "-cmd",
-            'SELECT "GenomicSQLite " || genomicsqlite_version()',
+            "SELECT 'GenomicSQLite ' || genomicsqlite_version()",
             "-cmd",
             ".headers on",
         ]


### PR DESCRIPTION
Hello,

For newer sqlite builds, the use of double quote for literal strings is by default disabled. This in turn cause the select version statement in genomicsqlite python binding to raise an error.

This is a tiny change to make the code not use this misfeature.

Thanks
